### PR TITLE
Fix submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/utilities"]
 	path = libs/utilities
-	url = git@github.com:amulware/utilities.git
+	url = https://github.com/amulware/utilities.git


### PR DESCRIPTION
This PR fixes the remote URL of the utilities submodule so it can be built by sources that do not have an SSH key setup (most notably build bots). Subsequently the submodule commit hash has been updated to an existing commit.
