### PR TITLE
Add a copy constructor to UpdateEventArgs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Declare the different kinds of text files, and make sure they always have the same line endings on checkout (unix)
+*.txt text eol=lf
+*.md text eol=lf
+*.cs text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.cshtml text eol=lf
+*.csproj text eol=lf
+*.csproj.DotSettings text eol=lf
+*.aspx text eol=lf
+*.ascx text eol=lf
+*.vm text eol=lf
+*.Master text eol=lf
+*.xprojtext eol=lf
+*.xproj.DotSettings text eol=lf
+*.xproj.user text eol=lf
+*.json text eol=lf
+*.xml text eol=lf
+*.config text eol=lf
+*.config.template text eol=lf
+*.msbuild text eol=lf
+
+*.sln text eol=lf
+*.vcproj text eol=lf
+*.vcxproj text eol=lf

--- a/src/amulware.Graphics/Window/UpdateEventArgs.cs
+++ b/src/amulware.Graphics/Window/UpdateEventArgs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace amulware.Graphics
 {
@@ -48,6 +48,17 @@ namespace amulware.Graphics
             this.ElapsedTimeInSf = (float)this.ElapsedTimeInS;
 
             this.TimeInS = currentTimeInSeconds;
+        }
+
+        /// <summary>
+        /// Initializes a new instance by copying from the given <see cref="UpdateEventArgs"/> class.
+        /// </summary>
+        /// <param name="updateEventArgs">The <see cref="UpdateEventArgs"/> instance to copy.</param>
+        public UpdateEventArgs(UpdateEventArgs updateEventArgs) {
+            this.Frame = updateEventArgs.Frame;
+            this.ElapsedTimeInS = updateEventArgs.ElapsedTimeInS;
+            this.ElapsedTimeInSf = updateEventArgs.ElapsedTimeInSf;
+            this.TimeInS = updateEventArgs.TimeInS;
         }
     }
 }


### PR DESCRIPTION
This allows the UpdateEventArgs to be subclassed, and allow user code to extend the UpdateEventArgs object that is being passed down from the amulware.Graphics `Program` code.