### PR TITLE
🧹 Clean up VertexData helper class

### DIFF
--- a/src/amulware.Graphics/Charts/FastChart2DBarVertex.cs
+++ b/src/amulware.Graphics/Charts/FastChart2DBarVertex.cs
@@ -16,8 +16,7 @@ namespace amulware.Graphics
                 VertexData.MakeAttributeTemplate<Color>("v_color")
                 );
         }
-
-        private static readonly int bytesize = VertexData.SizeOf<FastChart2DBarVertex>();
+        
         private static VertexAttribute[] attributes;
 
         public FastChart2DBarVertex(Vector2 position, Vector2 size, Color color)
@@ -30,11 +29,6 @@ namespace amulware.Graphics
         public VertexAttribute[] VertexAttributes()
         {
             return attributes ?? (attributes = makeAttributes());
-        }
-
-        public int Size()
-        {
-            return bytesize;
         }
     }
 }

--- a/src/amulware.Graphics/Core/vertexdata/IVertexData.cs
+++ b/src/amulware.Graphics/Core/vertexdata/IVertexData.cs
@@ -11,11 +11,5 @@ namespace amulware.Graphics
         /// </summary>
         /// <returns>Array of <see cref="VertexAttribute"/></returns>
         VertexAttribute[] VertexAttributes();
-
-        /// <summary>
-        /// This method returns the size of the vertex data struct in bytes
-        /// </summary>
-        /// <returns>Struct's size in bytes</returns>
-        int Size();
     }
 }

--- a/src/amulware.Graphics/Core/vertexdata/VertexAttributeTemplate.cs
+++ b/src/amulware.Graphics/Core/vertexdata/VertexAttributeTemplate.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using OpenTK.Graphics.OpenGL;
+
+namespace amulware.Graphics
+{
+    /// <summary>
+    /// Represents a template to create a VertexAttribute from.
+    /// </summary>
+    public sealed class VertexAttributeTemplate
+    {
+        private static readonly ImmutableDictionary<VertexAttribPointerType, int> attributeByteSizes
+            = ImmutableDictionary.CreateRange(new Dictionary<VertexAttribPointerType, int>
+            {
+                { VertexAttribPointerType.Byte, 1 },
+                { VertexAttribPointerType.UnsignedByte, 1 },
+                { VertexAttribPointerType.Short, 2 },
+                { VertexAttribPointerType.UnsignedShort, 2 },
+                { VertexAttribPointerType.HalfFloat, 2 },
+                { VertexAttribPointerType.Int, 4 },
+                { VertexAttribPointerType.UnsignedInt, 4 },
+                { VertexAttribPointerType.Float, 4 },
+                { VertexAttribPointerType.Double, 8 },
+            });
+        
+        private readonly string name;
+        private readonly int size;
+        private readonly VertexAttribPointerType type;
+        private readonly bool normalize;
+
+        /// <summary>
+        /// The size in bytes of this template's attribute.
+        /// </summary>
+        public int Bytes { get; }
+
+        internal VertexAttributeTemplate(string name, int size, VertexAttribPointerType type, bool normalize)
+        {
+            if (!attributeByteSizes.TryGetValue(type, out var bytes))
+                throw new ArgumentException($"Unknown VertexAttribPointerType: {type}");
+
+            Bytes = bytes * size;
+            this.name = name;
+            this.size = size;
+            this.type = type;
+            this.normalize = normalize;
+        }
+
+        /// <summary>
+        /// Creates the attribute from this template given an offset and stride.
+        /// </summary>
+        /// <param name="offset">
+        /// Offset of the attribute in the vertex.
+        /// Corresponds to the sum of byte-sizes of preceding attributes.</param>
+        /// <param name="stride">
+        /// Stride of the vertex of the created attribute.
+        /// Corresponds to the sum of byte-sizes of all attributes of the vertex.</param>
+        public VertexAttribute ToAttribute(int offset, int stride) =>
+            new VertexAttribute(name, size, type, stride, offset, normalize);
+    }
+}

--- a/src/amulware.Graphics/Core/vertexdata/VertexData.cs
+++ b/src/amulware.Graphics/Core/vertexdata/VertexData.cs
@@ -19,13 +19,12 @@ namespace amulware.Graphics
         /// <typeparam name="T">The type to return the size of.</typeparam>
         public static int SizeOf<T>() => Marshal.SizeOf(typeof(T));
 
-        #region MakeAttributeArray()
         /// <summary>
         /// Creates a <see cref="VertexAttribute"/> array from a list of attribute templates.
         /// Offset and stride are calculated automatically, assuming zero padding.
         /// </summary>
         /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(IList<IAttributeTemplate> attributes)
+        public static VertexAttribute[] MakeAttributeArray(IList<VertexAttributeTemplate> attributes)
         {
             var stride = attributes.Sum(a => a.Bytes);
             var array = new VertexAttribute[attributes.Count];
@@ -44,71 +43,47 @@ namespace amulware.Graphics
         /// Offset and stride are calculated automatically, assuming zero padding.
         /// </summary>
         /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(params IAttributeTemplate[] attributes) =>
-            MakeAttributeArray((IList<IAttributeTemplate>) attributes);
+        public static VertexAttribute[] MakeAttributeArray(params VertexAttributeTemplate[] attributes) =>
+            MakeAttributeArray((IList<VertexAttributeTemplate>) attributes);
 
         /// <summary>
         /// Creates a <see cref="VertexAttribute"/> array from a list of attribute templates.
         /// Offset and stride are calculated automatically, assuming zero padding.
         /// </summary>
         /// <param name="attributes">The attribute templates.</param>
-        public static VertexAttribute[] MakeAttributeArray(IEnumerable<IAttributeTemplate> attributes) =>
+        public static VertexAttribute[] MakeAttributeArray(IEnumerable<VertexAttributeTemplate> attributes) =>
             MakeAttributeArray(attributes.ToList());
 
-        #endregion
-
-        #region Dictionaries
-        private static readonly ImmutableDictionary<Type, AttributeTypeInfo> knownTypes
-        #region init
-            = ImmutableDictionary.CreateRange(new Dictionary<Type, AttributeTypeInfo>
+        private static readonly ImmutableDictionary<Type, (VertexAttribPointerType Type, int Count, bool DefaultNormalize)> knownTypes
+            = ImmutableDictionary.CreateRange(new Dictionary<Type, (VertexAttribPointerType, int, bool)>
             {
-                { typeof(float), toInfo(VertexAttribPointerType.Float, 1, defaultNormalize: false) },
-                { typeof(Vector2), toInfo(VertexAttribPointerType.Float, 2, defaultNormalize: false) },
-                { typeof(Vector3), toInfo(VertexAttribPointerType.Float, 3, defaultNormalize: false) },
-                { typeof(Vector4), toInfo(VertexAttribPointerType.Float, 4, defaultNormalize: false) },
+                { typeof(float), (VertexAttribPointerType.Float, 1, false) },
+                { typeof(Vector2), (VertexAttribPointerType.Float, 2, false) },
+                { typeof(Vector3), (VertexAttribPointerType.Float, 3, false) },
+                { typeof(Vector4), (VertexAttribPointerType.Float, 4, false) },
 
-                { typeof(Half), toInfo(VertexAttribPointerType.HalfFloat, 1, defaultNormalize: false) },
-                { typeof(Vector2h), toInfo(VertexAttribPointerType.HalfFloat, 2, defaultNormalize: false) },
-                { typeof(Vector3h), toInfo(VertexAttribPointerType.HalfFloat, 3, defaultNormalize: false) },
-                { typeof(Vector4h), toInfo(VertexAttribPointerType.HalfFloat, 4, defaultNormalize: false) },
+                { typeof(Half), (VertexAttribPointerType.HalfFloat, 1, false) },
+                { typeof(Vector2h), (VertexAttribPointerType.HalfFloat, 2, false) },
+                { typeof(Vector3h), (VertexAttribPointerType.HalfFloat, 3, false) },
+                { typeof(Vector4h), (VertexAttribPointerType.HalfFloat, 4, false) },
 
-                { typeof(double), toInfo(VertexAttribPointerType.Double, 1, defaultNormalize: false) },
-                { typeof(Vector2d), toInfo(VertexAttribPointerType.HalfFloat, 2, defaultNormalize: false) },
-                { typeof(Vector3d), toInfo(VertexAttribPointerType.HalfFloat, 3, defaultNormalize: false) },
-                { typeof(Vector4d), toInfo(VertexAttribPointerType.HalfFloat, 4, defaultNormalize: false) },
+                { typeof(double), (VertexAttribPointerType.Double, 1, false) },
+                { typeof(Vector2d), (VertexAttribPointerType.HalfFloat, 2, false) },
+                { typeof(Vector3d), (VertexAttribPointerType.HalfFloat, 3, false) },
+                { typeof(Vector4d), (VertexAttribPointerType.HalfFloat, 4, false) },
 
-                { typeof(byte), toInfo(VertexAttribPointerType.UnsignedByte, 1, defaultNormalize: true) },
-                { typeof(sbyte), toInfo(VertexAttribPointerType.Byte, 1, defaultNormalize: true) },
+                { typeof(byte), (VertexAttribPointerType.UnsignedByte, 1, true) },
+                { typeof(sbyte), (VertexAttribPointerType.Byte, 1, true) },
 
-                { typeof(short), toInfo(VertexAttribPointerType.Short, 1, defaultNormalize: false) },
-                { typeof(ushort), toInfo(VertexAttribPointerType.UnsignedShort, 1, defaultNormalize: false) },
+                { typeof(short), (VertexAttribPointerType.Short, 1, false) },
+                { typeof(ushort), (VertexAttribPointerType.UnsignedShort, 1, false) },
 
-                { typeof(int), toInfo(VertexAttribPointerType.Int, 1, defaultNormalize: false) },
-                { typeof(uint), toInfo(VertexAttribPointerType.UnsignedInt, 1, defaultNormalize: false) },
+                { typeof(int), (VertexAttribPointerType.Int, 1, false) },
+                { typeof(uint), (VertexAttribPointerType.UnsignedInt, 1, false) },
 
-                { typeof(Color), toInfo(VertexAttribPointerType.UnsignedByte, 4, defaultNormalize: true) },
+                { typeof(Color), (VertexAttribPointerType.UnsignedByte, 4, true) },
             });
-        #endregion
 
-        private static readonly ImmutableDictionary<VertexAttribPointerType, int> attribByteSizes
-        #region init
-            = ImmutableDictionary.CreateRange(new Dictionary<VertexAttribPointerType, int>
-            {
-                { VertexAttribPointerType.Byte, 1 },
-                { VertexAttribPointerType.UnsignedByte, 1 },
-                { VertexAttribPointerType.Short, 2 },
-                { VertexAttribPointerType.UnsignedShort, 2 },
-                { VertexAttribPointerType.HalfFloat, 2 },
-                { VertexAttribPointerType.Int, 4 },
-                { VertexAttribPointerType.UnsignedInt, 4 },
-                { VertexAttribPointerType.Float, 4 },
-                { VertexAttribPointerType.Double, 8 },
-            });
-        #endregion
-
-        #endregion
-
-        #region MakeAttributeTemplate()
         /// <summary>
         /// Creates a vertex attribute template of a given basic type with and a given name.
         /// </summary>
@@ -124,7 +99,7 @@ namespace amulware.Graphics
         /// three and four dimensional vectors of all three floating point types, and <see cref="Color"/>.
         /// </typeparam>
         /// <exception cref="ArgumentException">The given type is not supported.</exception>
-        public static IAttributeTemplate MakeAttributeTemplate<T>(string name, bool? normalize = null) =>
+        public static VertexAttributeTemplate MakeAttributeTemplate<T>(string name, bool? normalize = null) =>
             MakeAttributeTemplate(name, typeof (T), normalize);
 
         /// <summary>
@@ -142,7 +117,7 @@ namespace amulware.Graphics
         /// Default is null.
         /// </param>
         /// <exception cref="ArgumentException">The given type is not supported.</exception>
-        public static IAttributeTemplate MakeAttributeTemplate(string name, Type type, bool? normalize = null)
+        public static VertexAttributeTemplate MakeAttributeTemplate(string name, Type type, bool? normalize = null)
         {
             if(!knownTypes.TryGetValue(type, out var info))
                 throw new ArgumentException($"Unknown type: {type.Name}");
@@ -157,76 +132,8 @@ namespace amulware.Graphics
         /// <param name="type">The <see cref="VertexAttribPointerType"/> of the attribute.</param>
         /// <param name="numberOfType">Number of components of the given type in this attribute.</param>
         /// <param name="normalize">Whether to normalize the attribute.</param>
-        public static IAttributeTemplate MakeAttributeTemplate(
+        public static VertexAttributeTemplate MakeAttributeTemplate(
                 string name, VertexAttribPointerType type, int numberOfType, bool normalize = false) =>
-            new AttributeTemplate(name, numberOfType, type, normalize);
-
-        #endregion
-
-        #region Types
-        /// <summary>
-        /// Represents a template to create a VertexAttribute from.
-        /// </summary>
-        public interface IAttributeTemplate
-        {
-            /// <summary>
-            /// The size in bytes of this template's attribute.
-            /// </summary>
-            int Bytes { get; }
-            /// <summary>
-            /// Creates the attribute from this template given an offset and stride.
-            /// </summary>
-            /// <param name="offset">
-            /// Offset of the attribute in the vertex.
-            /// Corresponds to the sum of byte-sizes of preceding attributes.</param>
-            /// <param name="stride">
-            /// Stride of the vertex of the created attribute.
-            /// Corresponds to the sum of byte-sizes of all attributes of the vertex.</param>
-            VertexAttribute ToAttribute(int offset, int stride);
-        }
-
-        private struct AttributeTypeInfo
-        {
-            public VertexAttribPointerType Type { get; }
-            public int Count { get; }
-            public bool DefaultNormalize { get; }
-
-            public AttributeTypeInfo(VertexAttribPointerType type, int count, bool defaultNormalize)
-                : this()
-            {
-                Type = type;
-                Count = count;
-                DefaultNormalize = defaultNormalize;
-            }
-        }
-
-        private static AttributeTypeInfo toInfo(VertexAttribPointerType type, int count, bool defaultNormalize) =>
-            new AttributeTypeInfo(type, count, defaultNormalize);
-
-        private sealed class AttributeTemplate : IAttributeTemplate
-        {
-            private readonly string name;
-            private readonly int size;
-            private readonly VertexAttribPointerType type;
-            private readonly bool normalize;
-
-            public int Bytes { get; }
-
-            public AttributeTemplate(string name, int size, VertexAttribPointerType type, bool normalize)
-            {
-                if (!attribByteSizes.TryGetValue(type, out var bytes))
-                    throw new ArgumentException($"Unknown VertexAttribPointerType: {type}");
-
-                Bytes = bytes * size;
-                this.name = name;
-                this.size = size;
-                this.type = type;
-                this.normalize = normalize;
-            }
-
-            public VertexAttribute ToAttribute(int offset, int stride) =>
-                new VertexAttribute(name, size, type, stride, offset, normalize);
-        }
-        #endregion
+            new VertexAttributeTemplate(name, numberOfType, type, normalize);
     }
 }

--- a/src/amulware.Graphics/Meshes/MeshVertex.cs
+++ b/src/amulware.Graphics/Meshes/MeshVertex.cs
@@ -40,7 +40,6 @@ namespace amulware.Graphics.Meshes
 
         #region IVertexData
 
-        private static readonly int size = VertexData.SizeOf<MeshVertex>();
         private static VertexAttribute[] vertexArray;
 
         public VertexAttribute[] VertexAttributes()
@@ -54,11 +53,6 @@ namespace amulware.Graphics.Meshes
                 VertexData.MakeAttributeTemplate<Vector3>("v_position"),
                 VertexData.MakeAttributeTemplate<Vector3>("v_normal")
                 );
-        }
-
-        public int Size()
-        {
-            return size;
         }
 
         #endregion


### PR DESCRIPTION
The class was a bit of a mess, so I did the following:

- remove #region because I really don't like how they clutter things anymore
- remove the internal AttributeTypeInfo in favour of simpler tuples
- remove the IAttributeTemplate interface and just expose the only implementation of it directly
- move that implementation to its own file

This is a breaking change, but source compatibility is maintained, so it's not a big deal.

I also removed IVertexData.Size which was never used.