### PR TITLE
🔡 Use a fallback glyph for fonts

### DIFF
--- a/src/amulware.Graphics/Text/Font.cs
+++ b/src/amulware.Graphics/Text/Font.cs
@@ -7,14 +7,29 @@ namespace amulware.Graphics.Text
     {
         private readonly ImmutableDictionary<char, CharacterInfo> characters;
 
-        public Font(ImmutableDictionary<char, CharacterInfo> characters)
+        public CharacterInfo FallbackCharacter { get; }
+
+        public Font(ImmutableDictionary<char, CharacterInfo> characters, CharacterInfo fallbackCharacter)
         {
             this.characters = characters;
+            FallbackCharacter = fallbackCharacter;
         }
 
         public CharacterInfo GetCharacterInfoFor(char character)
         {
-            return characters[character];
+            return TryGetCharacterInfoFor(character, out var info) ? info : FallbackCharacter;
+        }
+
+        public bool TryGetCharacterInfoFor(char character, out CharacterInfo characterInfo)
+        {
+            if (characters.TryGetValue(character, out var foundValue))
+            {
+                characterInfo = foundValue;
+                return true;
+            }
+
+            characterInfo = default;
+            return false;
         }
 
         public float StringWidth(string text)

--- a/src/amulware.Graphics/Text/FontFactory.cs
+++ b/src/amulware.Graphics/Text/FontFactory.cs
@@ -32,6 +32,8 @@ namespace amulware.Graphics.Text
 
         private sealed class Builder : IDisposable
         {
+            private const char fallbackGlyph = '�';
+
             private readonly System.Drawing.Font font;
             private readonly IEnumerable<char> supportedCharacters;
             private readonly int pixelPadding;
@@ -76,7 +78,7 @@ namespace amulware.Graphics.Text
                 var brush = new SolidBrush(System.Drawing.Color.White);
                 var drawPos = new PointF(font.Height, font.Height);
 
-                foreach (var c in supportedCharacters)
+                foreach (var c in supportedCharacters.Concat(new[] {fallbackGlyph}))
                 {
                     g.Clear(System.Drawing.Color.FromArgb(0, 0, 0, 0));
                     g.DrawString(c.ToString(), font, brush, drawPos);
@@ -175,9 +177,10 @@ namespace amulware.Graphics.Text
             private Font buildFont(int textureWidth, int textureHeight)
             {
                 return new Font(
-                    characterInfos.ToImmutableDictionary(
-                        entry => entry.Key,
-                        entry => toCharacterInfo(entry.Value, textureWidth, textureHeight)));
+                    supportedCharacters.ToImmutableDictionary(
+                        c => c,
+                        c => toCharacterInfo(characterInfos[c], textureWidth, textureHeight)),
+                    toCharacterInfo(characterInfos[fallbackGlyph], textureWidth, textureHeight));
             }
 
             private CharacterInfo toCharacterInfo(MutableCharacterInfo info, int textureWidth, int textureHeight)


### PR DESCRIPTION
* `TryGetCharacterInfoFor` was added. It will return false if it can't find the character.
* `GetCharacterInfoFor` will no longer throw, and return a fallback glyph.
* The fallback glyph is automatically used for string measuring.