### PR TITLE
⬆ Upgrade to OpenTK stable, including .NET version changes

### DIFF
--- a/src/amulware.Graphics/Core/Buffer.cs
+++ b/src/amulware.Graphics/Core/Buffer.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics
 {

--- a/src/amulware.Graphics/Core/BufferStream.cs
+++ b/src/amulware.Graphics/Core/BufferStream.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics
 {

--- a/src/amulware.Graphics/Core/Color.cs
+++ b/src/amulware.Graphics/Core/Color.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics
 {

--- a/src/amulware.Graphics/Core/RenderSettings/ArrayTextureUniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/ArrayTextureUniform.cs
@@ -1,5 +1,5 @@
 using amulware.Graphics.Textures;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/ColorUniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/ColorUniform.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Graphics.OpenGL;
+﻿using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/FloatUniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/FloatUniform.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Graphics.OpenGL;
+﻿using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/Matrix4Uniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/Matrix4Uniform.cs
@@ -1,5 +1,5 @@
-﻿using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+﻿using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/TextureUniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/TextureUniform.cs
@@ -1,5 +1,5 @@
 ﻿using amulware.Graphics.Textures;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/Vector2Uniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/Vector2Uniform.cs
@@ -1,5 +1,5 @@
-﻿using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+﻿using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/Vector3Uniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/Vector3Uniform.cs
@@ -1,5 +1,5 @@
-﻿using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+﻿using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/RenderSettings/Vector4Uniform.cs
+++ b/src/amulware.Graphics/Core/RenderSettings/Vector4Uniform.cs
@@ -1,5 +1,5 @@
-﻿using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+﻿using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.RenderSettings
 {

--- a/src/amulware.Graphics/Core/Rendering/Renderable.ForBatched.cs
+++ b/src/amulware.Graphics/Core/Rendering/Renderable.ForBatched.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Rendering
 {

--- a/src/amulware.Graphics/Core/Rendering/Renderable.ForVertices.cs
+++ b/src/amulware.Graphics/Core/Rendering/Renderable.ForVertices.cs
@@ -1,6 +1,6 @@
 using amulware.Graphics.Shading;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Rendering
 {

--- a/src/amulware.Graphics/Core/Rendering/Renderable.ForVerticesAndIndices.cs
+++ b/src/amulware.Graphics/Core/Rendering/Renderable.ForVerticesAndIndices.cs
@@ -1,7 +1,7 @@
 using System;
 using amulware.Graphics.Shading;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Rendering
 {

--- a/src/amulware.Graphics/Core/Rendering/VertexArray.cs
+++ b/src/amulware.Graphics/Core/Rendering/VertexArray.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Rendering
 {

--- a/src/amulware.Graphics/Core/Shading/Shader.cs
+++ b/src/amulware.Graphics/Core/Shading/Shader.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Shading
 {

--- a/src/amulware.Graphics/Core/Shading/ShaderFactory.cs
+++ b/src/amulware.Graphics/Core/Shading/ShaderFactory.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Shading
 {

--- a/src/amulware.Graphics/Core/Shading/ShaderProgram.cs
+++ b/src/amulware.Graphics/Core/Shading/ShaderProgram.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Shading
 {

--- a/src/amulware.Graphics/Core/Textures/ArrayTexture.cs
+++ b/src/amulware.Graphics/Core/Textures/ArrayTexture.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Textures
 {

--- a/src/amulware.Graphics/Core/Textures/ArrayTextureData.cs
+++ b/src/amulware.Graphics/Core/Textures/ArrayTextureData.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Textures
 {

--- a/src/amulware.Graphics/Core/Textures/RenderTarget.cs
+++ b/src/amulware.Graphics/Core/Textures/RenderTarget.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Linq;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Textures
 {

--- a/src/amulware.Graphics/Core/Textures/Texture.cs
+++ b/src/amulware.Graphics/Core/Textures/Texture.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Textures
 {

--- a/src/amulware.Graphics/Core/Textures/TextureData.cs
+++ b/src/amulware.Graphics/Core/Textures/TextureData.cs
@@ -4,8 +4,8 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
-using OpenToolkit.Graphics.OpenGL;
-using PixelFormat = OpenToolkit.Graphics.OpenGL.PixelFormat;
+using OpenTK.Graphics.OpenGL;
+using PixelFormat = OpenTK.Graphics.OpenGL.PixelFormat;
 using SystemPixelFormat = System.Drawing.Imaging.PixelFormat;
 
 namespace amulware.Graphics.Textures

--- a/src/amulware.Graphics/Core/Vertices/VertexAttribute.cs
+++ b/src/amulware.Graphics/Core/Vertices/VertexAttribute.cs
@@ -1,5 +1,5 @@
 ﻿using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Vertices
 {

--- a/src/amulware.Graphics/Core/Vertices/VertexAttributeTemplate.cs
+++ b/src/amulware.Graphics/Core/Vertices/VertexAttributeTemplate.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Vertices
 {

--- a/src/amulware.Graphics/Core/Vertices/VertexData.cs
+++ b/src/amulware.Graphics/Core/Vertices/VertexData.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Vertices
 {
@@ -70,7 +70,7 @@ namespace amulware.Graphics.Vertices
                 { typeof(Vector3), (VertexAttribPointerType.Float, 3, false) },
                 { typeof(Vector4), (VertexAttribPointerType.Float, 4, false) },
 
-                { typeof(Half), (VertexAttribPointerType.HalfFloat, 1, false) },
+                { typeof(OpenTK.Mathematics.Half), (VertexAttribPointerType.HalfFloat, 1, false) },
                 { typeof(Vector2h), (VertexAttribPointerType.HalfFloat, 2, false) },
                 { typeof(Vector3h), (VertexAttribPointerType.HalfFloat, 3, false) },
                 { typeof(Vector4h), (VertexAttribPointerType.HalfFloat, 4, false) },

--- a/src/amulware.Graphics/MeshBuilders/ExpandingIndexedTrianglesMeshBuilder.cs
+++ b/src/amulware.Graphics/MeshBuilders/ExpandingIndexedTrianglesMeshBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using amulware.Graphics.Rendering;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.MeshBuilders
 {

--- a/src/amulware.Graphics/MeshBuilders/IndexedTrianglesMeshBuilder.cs
+++ b/src/amulware.Graphics/MeshBuilders/IndexedTrianglesMeshBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using amulware.Graphics.Rendering;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.MeshBuilders
 {

--- a/src/amulware.Graphics/Pipelines/Context/DepthMode.cs
+++ b/src/amulware.Graphics/Pipelines/Context/DepthMode.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Pipelines.Context
 {

--- a/src/amulware.Graphics/Pipelines/Context/GLState.cs
+++ b/src/amulware.Graphics/Pipelines/Context/GLState.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Drawing;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 using static amulware.Graphics.Pipelines.Context.CullMode;
-using static OpenToolkit.Graphics.OpenGL.BlendEquationMode;
-using static OpenToolkit.Graphics.OpenGL.BlendingFactor;
+using static OpenTK.Graphics.OpenGL.BlendEquationMode;
+using static OpenTK.Graphics.OpenGL.BlendingFactor;
 
 namespace amulware.Graphics.Pipelines.Context
 {

--- a/src/amulware.Graphics/Pipelines/Pipeline.Steps.cs
+++ b/src/amulware.Graphics/Pipelines/Pipeline.Steps.cs
@@ -7,9 +7,9 @@ using amulware.Graphics.PostProcessing;
 using amulware.Graphics.Rendering;
 using amulware.Graphics.RenderSettings;
 using amulware.Graphics.ShaderManagement;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
-using static OpenToolkit.Graphics.OpenGL.ClearBufferMask;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
+using static OpenTK.Graphics.OpenGL.ClearBufferMask;
 
 namespace amulware.Graphics.Pipelines
 {

--- a/src/amulware.Graphics/Pipelines/Pipeline.Textures.cs
+++ b/src/amulware.Graphics/Pipelines/Pipeline.Textures.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using amulware.Graphics.Textures;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Pipelines
 {

--- a/src/amulware.Graphics/Pipelines/PipelineTextureBase.cs
+++ b/src/amulware.Graphics/Pipelines/PipelineTextureBase.cs
@@ -1,6 +1,6 @@
 using System;
 using amulware.Graphics.Textures;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Pipelines
 {

--- a/src/amulware.Graphics/Pipelines/Steps/Clear.cs
+++ b/src/amulware.Graphics/Pipelines/Steps/Clear.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.Pipelines.Steps
 {

--- a/src/amulware.Graphics/Pipelines/Steps/Resize.cs
+++ b/src/amulware.Graphics/Pipelines/Steps/Resize.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Immutable;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Pipelines.Steps
 {

--- a/src/amulware.Graphics/PostProcessing/PostProcessingVertexData.cs
+++ b/src/amulware.Graphics/PostProcessing/PostProcessingVertexData.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 using static amulware.Graphics.Vertices.VertexData;
 
 namespace amulware.Graphics.PostProcessing

--- a/src/amulware.Graphics/PostProcessing/PostProcessor.cs
+++ b/src/amulware.Graphics/PostProcessing/PostProcessor.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using amulware.Graphics.Rendering;
 using amulware.Graphics.RenderSettings;
 using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.PostProcessing
 {

--- a/src/amulware.Graphics/ShaderManagement/IShaderReloader.cs
+++ b/src/amulware.Graphics/ShaderManagement/IShaderReloader.cs
@@ -1,5 +1,5 @@
 using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/ShaderManagement/ReloadableShader.cs
+++ b/src/amulware.Graphics/ShaderManagement/ReloadableShader.cs
@@ -1,6 +1,6 @@
 using System;
 using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/ShaderManagement/ShaderFile.cs
+++ b/src/amulware.Graphics/ShaderManagement/ShaderFile.cs
@@ -1,6 +1,6 @@
 using System.IO;
 using amulware.Graphics.Shading;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/ShaderManagement/ShaderFileLoader.cs
+++ b/src/amulware.Graphics/ShaderManagement/ShaderFileLoader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using OpenToolkit.Graphics.OpenGL;
+using OpenTK.Graphics.OpenGL;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/ShaderManagement/ShaderManager.ProgramBuilder.cs
+++ b/src/amulware.Graphics/ShaderManagement/ShaderManager.ProgramBuilder.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using OpenToolkit.Graphics.OpenGL;
-using static OpenToolkit.Graphics.OpenGL.ShaderType;
+using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.ShaderType;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/ShaderManagement/ShaderManager.cs
+++ b/src/amulware.Graphics/ShaderManagement/ShaderManager.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using OpenToolkit.Graphics.OpenGL;
-using static OpenToolkit.Graphics.OpenGL.ShaderType;
+using OpenTK.Graphics.OpenGL;
+using static OpenTK.Graphics.OpenGL.ShaderType;
 
 namespace amulware.Graphics.ShaderManagement
 {

--- a/src/amulware.Graphics/Shapes/ColorVertexData.cs
+++ b/src/amulware.Graphics/Shapes/ColorVertexData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 using static amulware.Graphics.Vertices.VertexData;
 
 namespace amulware.Graphics.Shapes

--- a/src/amulware.Graphics/Shapes/IShapeDrawer3.cs
+++ b/src/amulware.Graphics/Shapes/IShapeDrawer3.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Shapes
 {

--- a/src/amulware.Graphics/Shapes/ShapeDrawer2.cs
+++ b/src/amulware.Graphics/Shapes/ShapeDrawer2.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using amulware.Graphics.MeshBuilders;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Shapes
 {

--- a/src/amulware.Graphics/Shapes/ShapeDrawer2Extensions.cs
+++ b/src/amulware.Graphics/Shapes/ShapeDrawer2Extensions.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Shapes
 {

--- a/src/amulware.Graphics/Shapes/ShapeDrawer3.cs
+++ b/src/amulware.Graphics/Shapes/ShapeDrawer3.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using amulware.Graphics.MeshBuilders;
 using amulware.Graphics.Vertices;
 using Bearded.Utilities;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Shapes
 {

--- a/src/amulware.Graphics/Shapes/ShapeDrawer3Extensions.cs
+++ b/src/amulware.Graphics/Shapes/ShapeDrawer3Extensions.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Shapes
 {

--- a/src/amulware.Graphics/Text/CharacterInfo.cs
+++ b/src/amulware.Graphics/Text/CharacterInfo.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Text/FontFactory.cs
+++ b/src/amulware.Graphics/Text/FontFactory.cs
@@ -10,7 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using amulware.Graphics.Textures;
 using Bearded.Utilities.Algorithms;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Text/ITextDrawer.cs
+++ b/src/amulware.Graphics/Text/ITextDrawer.cs
@@ -1,4 +1,4 @@
-using Vector3 = OpenToolkit.Mathematics.Vector3;
+using Vector3 = OpenTK.Mathematics.Vector3;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Text/TextDrawer.cs
+++ b/src/amulware.Graphics/Text/TextDrawer.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using amulware.Graphics.MeshBuilders;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Text/TextDrawerExtensions.cs
+++ b/src/amulware.Graphics/Text/TextDrawerExtensions.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Text/TextDrawerWithDefaults.cs
+++ b/src/amulware.Graphics/Text/TextDrawerWithDefaults.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace amulware.Graphics.Text
 {

--- a/src/amulware.Graphics/Windowing/Window.cs
+++ b/src/amulware.Graphics/Windowing/Window.cs
@@ -2,9 +2,9 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Desktop;
-using OpenToolkit.Windowing.GraphicsLibraryFramework;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace amulware.Graphics.Windowing
 {
@@ -44,7 +44,7 @@ namespace amulware.Graphics.Windowing
 
         private readonly NativeWindowWrapper window;
 
-        // TODO(#26): rewrite windowing natively and merge with input, instead of relying on OpenToolkit.Windowing.Desktop
+        // TODO(#26): rewrite windowing natively and merge with input, instead of relying on OpenTK.Windowing.Desktop
         [Obsolete("Legacy implementation. There is no replacement yet.")]
         protected NativeWindow NativeWindow => window;
 

--- a/src/amulware.Graphics/amulware.Graphics.csproj
+++ b/src/amulware.Graphics/amulware.Graphics.csproj
@@ -5,20 +5,20 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>8</LangVersion>
     <Nullable>annotations</Nullable>
-    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bearded.Utilities" Version="0.2.0.318-dev" />
+    <PackageReference Include="Bearded.Utilities" Version="0.2.0.393-dev" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Common" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.GraphicsLibraryFramework" Version="4.0.0-pre9.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.4.0" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.4.0" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.4.0" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.4.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
* This PR changes the .NET target frameworks to be in line with the Bearded ones.
* I needed to specify the `Half` type, because there is now both a `System.Half` and `OpenTK.Mathematics.Half`. The former caused another error when specifying explicitly, so I stuck with the latter one.
* This PR updates the OpenTK references and .NET System libraries.