### PR TITLE
🧯 Fix the examples

### DIFF
--- a/examples/01.Basics/GameWindow.cs
+++ b/examples/01.Basics/GameWindow.cs
@@ -5,10 +5,10 @@ using amulware.Graphics.RenderSettings;
 using amulware.Graphics.Shading;
 using amulware.Graphics.Shapes;
 using amulware.Graphics.Windowing;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Desktop;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace amulware.Graphics.Examples.Basics
 {

--- a/examples/01.Basics/amulware.Graphics.Examples.01.Basics.csproj
+++ b/examples/01.Basics/amulware.Graphics.Examples.01.Basics.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>amulware.Graphics.Examples.Basics</RootNamespace>
     <AssemblyName>amulware.Graphics.Examples.Basics</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
@@ -16,10 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\amulware.Graphics\amulware.Graphics.csproj" />
   </ItemGroup>

--- a/examples/02.IndexBuffer/GameWindow.cs
+++ b/examples/02.IndexBuffer/GameWindow.cs
@@ -4,10 +4,10 @@ using amulware.Graphics.Rendering;
 using amulware.Graphics.Shading;
 using amulware.Graphics.Shapes;
 using amulware.Graphics.Windowing;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Desktop;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace amulware.Graphics.Examples.IndexBuffer
 {

--- a/examples/02.IndexBuffer/amulware.Graphics.Examples.02.IndexBuffer.csproj
+++ b/examples/02.IndexBuffer/amulware.Graphics.Examples.02.IndexBuffer.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>amulware.Graphics.Examples.IndexBuffer</RootNamespace>
     <AssemblyName>amulware.Graphics.Examples.IndexBuffer</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
@@ -16,10 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\amulware.Graphics\amulware.Graphics.csproj" />
   </ItemGroup>

--- a/examples/08.PostProcessing/GameWindow.cs
+++ b/examples/08.PostProcessing/GameWindow.cs
@@ -65,7 +65,8 @@ namespace amulware.Graphics.Examples.PostProcessing
 
             meshBuilder = new IndexedTrianglesMeshBuilder<ColorVertexData>();
 
-            var shapeDrawer = new ColorShapeDrawer3(meshBuilder);
+            var shapeDrawer =
+                new ShapeDrawer3<ColorVertexData, Color>(meshBuilder, (xyz, color) => new ColorVertexData(xyz, color));
             shapeDrawer.DrawCube(Vector3.Zero, 1f, Color.Aqua);
 
             var shapeRenderable = meshBuilder.ToRenderable();

--- a/examples/08.PostProcessing/GameWindow.cs
+++ b/examples/08.PostProcessing/GameWindow.cs
@@ -8,10 +8,10 @@ using amulware.Graphics.Shading;
 using amulware.Graphics.Shapes;
 using amulware.Graphics.Textures;
 using amulware.Graphics.Windowing;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Desktop;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace amulware.Graphics.Examples.PostProcessing
 {

--- a/examples/08.PostProcessing/amulware.Graphics.Examples.08.PostProcessing.csproj
+++ b/examples/08.PostProcessing/amulware.Graphics.Examples.08.PostProcessing.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>amulware.Graphics.Examples.PostProcessing</RootNamespace>
     <AssemblyName>amulware.Graphics.Examples.PostProcessing</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
@@ -16,10 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\amulware.Graphics\amulware.Graphics.csproj" />
   </ItemGroup>

--- a/examples/12.Text/GameWindow.cs
+++ b/examples/12.Text/GameWindow.cs
@@ -7,10 +7,10 @@ using amulware.Graphics.Shading;
 using amulware.Graphics.Text;
 using amulware.Graphics.Textures;
 using amulware.Graphics.Windowing;
-using OpenToolkit.Graphics.OpenGL;
-using OpenToolkit.Mathematics;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Desktop;
+using OpenTK.Graphics.OpenGL;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace amulware.Graphics.Examples.Text
 {

--- a/examples/12.Text/UVVertexData.cs
+++ b/examples/12.Text/UVVertexData.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using amulware.Graphics.Vertices;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 using static amulware.Graphics.Vertices.VertexData;
 
 namespace amulware.Graphics.Examples.Text

--- a/examples/12.Text/amulware.Graphics.Examples.12.Text.csproj
+++ b/examples/12.Text/amulware.Graphics.Examples.12.Text.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>amulware.Graphics.Examples.Text</RootNamespace>
     <AssemblyName>amulware.Graphics.Examples.Text</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>annotations</Nullable>
@@ -16,10 +16,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\amulware.Graphics\amulware.Graphics.csproj" />
   </ItemGroup>

--- a/examples/20.Mandelbrot/amulware.Graphics.Examples.20.Mandelbrot.csproj
+++ b/examples/20.Mandelbrot/amulware.Graphics.Examples.20.Mandelbrot.csproj
@@ -17,10 +17,6 @@
     <OutputPath>bin/Release/</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Desktop" Version="4.0.0-pre9.1" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\src\amulware.Graphics\amulware.Graphics.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The examples were broken for a variety of reasons:

1. OpenTK was updated, but the examples were still built on the old OpenTK references.
2. Breaking changes were made to the shape and text drawers. The examples weren't updated.

This PR addresses both. I ran all the examples locally and the ran successfully.