### PR TITLE
🔥 Remove Newtonsoft.Json dependency

### DIFF
--- a/Bearded.Graphics/Bearded.Graphics.csproj
+++ b/Bearded.Graphics/Bearded.Graphics.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Bearded.Utilities" Version="0.2.0.393-dev" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="OpenTK.Graphics" Version="4.4.0" />
     <PackageReference Include="OpenTK.Windowing.Common" Version="4.4.0" />
     <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.4.0" />


### PR DESCRIPTION
## ✨ What's this?
This PR removes the NuGet dependency on Newtonsoft.Json.

### 🔗 Relationships
Makes #57 obsolete.

## 🔍 Why do we want this?
It is no longer used.

## 🏗 How is it done?
Select. Delete.

### 💥 Breaking changes
Might break libraries and applications that depended on Newtonsoft.Json indirectly through Bearded.Graphics.

## 💡 Review hints
Confirmed that this works in TD.
